### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
- * @infratographer/the_committee @infratographer/sig-community
+* @infratographer/the_committee @infratographer/sig-bootstrap


### PR DESCRIPTION
- Add sig-bootstrap to CODEOWNERS
- Dropped sig-community because it appeared to be invalid